### PR TITLE
another way to access colony_user properties

### DIFF
--- a/app/models/colony.rb
+++ b/app/models/colony.rb
@@ -13,4 +13,10 @@ class Colony < ActiveRecord::Base
       o.user
     end
   end
+
+  def volunteers
+    self.colony_users.where(volunteer: true).map do |v|
+      v.user
+    end
+  end
 end

--- a/app/views/colonies/show.html.erb
+++ b/app/views/colonies/show.html.erb
@@ -12,6 +12,20 @@
     <div>Environment: <%= @colony.enviroment %></div>
     <div>Population: <%= @colony.pop %></div>
     <div>Veterinarian: <%= @colony.vet %></div>
+    <% unless @colony.owners == [] %>
+      <div>Colony Owner(s):
+        <%= @colony.owners.each do |o| %>
+          <%= o.display_name %>
+        <% end %>
+      </div>
+    <% end %>
+    <% unless @colony.volunteers == [] %>
+      <div>Colony Volunteer(s):
+        <%= @colony.volunteers.each do |v| %>
+          <%= v.display_name %>
+        <% end %>
+      </div>
+    <% end %>
     <div>
       <%= link_to '[edit]', edit_colony_path(@colony) %>
       <%= link_to '[remove]', @colony, method: :delete, data: {confirm: 'Are you sure?'} %>

--- a/test/fixtures/colony_users.yml
+++ b/test/fixtures/colony_users.yml
@@ -4,3 +4,10 @@ one:
   owner: true
   volunteer: false
   care_taker: true
+
+two:
+  user_id: 3
+  colony_id: 1
+  owner: false
+  volunteer: true
+  care_taker: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -14,3 +14,11 @@ two:
   first_name: Jane
   last_name: Doe
   display_name: callmefourpaws
+
+three:
+  id: 3
+  email: baz@foo.bar
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
+  first_name: Jim
+  last_name: Doe
+  display_name: jimmythecat

--- a/test/models/colony_test.rb
+++ b/test/models/colony_test.rb
@@ -52,7 +52,7 @@ class ColonyTest < ActiveSupport::TestCase
 
   test 'can access an owner' do
     assert_respond_to @colony, :owners
-    assert_equal [@user], @colony.owners
+    assert_equal @user, @colony.owners[0]
   end
 
   test 'can access multiple owners' do
@@ -64,4 +64,9 @@ class ColonyTest < ActiveSupport::TestCase
     end
   end
 
+  test 'can access volunteers' do
+    assert_respond_to @colony, :volunteers
+    user3 = users(:three)
+    assert_includes @colony.volunteers, user3
+  end
 end


### PR DESCRIPTION
tests are still green

There are a lot of ways we can handle the requests for owner/volunteer/care_taker for a colony, this is just an example of how it could work. Modify to best suit your needs.